### PR TITLE
Fix broken links to dicot-project site/repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Dicot website README
 ====================
 
 This repository provides the content behind the [Dicot project
-website](http://dicot.github.io).
+website](http://dicot-project.github.io).
 
 The site is using the Jekyll content publishing framework to allow the site to
 be served from github pages.

--- a/contrib.md
+++ b/contrib.md
@@ -60,7 +60,7 @@ control system, [hosted on github](https://github.com/dicot-project/). The
 primary repositories are:
 
 * [dicot-api](https://github.com/dicot-project/dicot-api) - The REST APIs to enable OpenStack compatible clients to use KubeVirt and Kubernetes
-* [dicot.github.io](https://github.com/dicot-project/dicot.github.io) - The source for this entire website
+* [dicot.github.io](https://github.com/dicot-project/dicot-project.github.io) - The source for this entire website
 
 ### Social media
 


### PR DESCRIPTION
These links were broken, updating to point at the project
website and repository

Signed-off-by: Steven Hardy <shardy@redhat.com>